### PR TITLE
Added feature rememberExoplayerState

### DIFF
--- a/app/src/main/java/com/palankibharat/exoplayerplus/MainActivity.kt
+++ b/app/src/main/java/com/palankibharat/exoplayerplus/MainActivity.kt
@@ -2,6 +2,7 @@ package com.palankibharat.exoplayerplus
 
 import android.content.pm.ActivityInfo
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.clickable
@@ -30,6 +31,8 @@ import androidx.compose.ui.unit.dp
 import com.palankibharat.exo_compose_player.PipInitializer
 import com.palankibharat.exo_compose_player.ComposePlayPauseButton
 import com.palankibharat.exo_compose_player.ExoComposePlayer
+import com.palankibharat.exo_compose_player.PlayerStates
+import com.palankibharat.exo_compose_player.rememberExoplayerState
 import com.palankibharat.exoplayerplus.ui.theme.ExoPlayerPlusTheme
 
 class MainActivity : ComponentActivity() {
@@ -46,12 +49,25 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background,
                 ) {
+
+                    val exoPlayerState = rememberExoplayerState()
+
+                    // access player state
+                    val playerState by exoPlayerState
+
+                    /*
+                    to update  player state we can use
+
+                    exoPlayerState.updateState(newPlayerStates = PlayerStates())
+                    */
+
                     Column {
                         ExoComposePlayer(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .aspectRatio(16f / 9f),
                             mediaUrl = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+                            exoPlayerState = exoPlayerState
                         )
                     }
                 }

--- a/exoplayer-plus/src/main/java/com/palankibharat/exo_compose_player/rememberExoplayerState.kt
+++ b/exoplayer-plus/src/main/java/com/palankibharat/exo_compose_player/rememberExoplayerState.kt
@@ -1,0 +1,119 @@
+package com.palankibharat.exo_compose_player
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.platform.LocalContext
+
+
+/**
+ * Provides a composable to remember the ExoPlayer state with ability to save and restore
+ * its instance state across configuration changes.
+ * It utilizes the rememberSaveable composable to automatically save and restore the ExoPlayer state.
+ * @return [ExoPlayerState] instance with the initial brightness level set from the current context.
+ */
+@Composable
+fun rememberExoplayerState(): ExoPlayerState {
+    val context = LocalContext.current
+    val defaultBrightness = context.getCurrentBrightness()
+
+    return rememberSaveable(saver = ExoPlayerState.ExoPlayerStateSaver) {
+        ExoPlayerState(
+            initialBrightnessLevel = defaultBrightness,
+        )
+    }
+}
+
+/**
+ * Represents the state of an ExoPlayer with properties for UI control visibility,
+ * player mode, total duration, brightness level, and playback status.
+ * It implements MutableState to allow for state observation and updates.
+ * @property initialBrightnessLevel Initial brightness level of the player.
+ */
+class ExoPlayerState(
+    initialBrightnessLevel: Float = 0f,
+) : MutableState<PlayerStates> {
+
+    private val mutableState = mutableStateOf(
+        PlayerStates(
+            brightnessLevel = initialBrightnessLevel,
+        )
+    )
+
+    override var value: PlayerStates
+        get() = mutableState.value
+        set(newValue) {
+            mutableState.value = newValue
+        }
+
+    override fun component1(): PlayerStates = mutableState.value
+
+    override fun component2(): (PlayerStates) -> Unit = { newValue -> mutableState.value = newValue }
+
+    /**
+     * Updates the current state of the ExoPlayer with new player states.
+     * @param newPlayerStates New states to be applied to the player.
+     */
+    fun updateState(newPlayerStates: PlayerStates) {
+        value = newPlayerStates
+    }
+
+    companion object{
+
+        val ExoPlayerStateSaver = Saver<ExoPlayerState, List<Any>>(
+            save = { state ->
+                // Save all properties of PlayerStates in a list
+                listOf(
+                    state.value.areControlsVisible,
+                    state.value.playerMode,
+                    state.value.totalDuration,
+                    state.value.brightnessLevel,
+                    state.value.isPlayingValue,
+                )
+            },
+            restore = { restored ->
+                // Restore the state from the list
+                ExoPlayerState(
+                    initialBrightnessLevel = restored[3] as Float,
+                ).apply {
+                    // Apply the restored state to the mutable state
+                    this.updateState(
+                        PlayerStates(
+                            areControlsVisible = restored[0] as Boolean,
+                            playerMode = restored[1] as PlayerModes,
+                            totalDuration = restored[2] as Long,
+                            brightnessLevel = restored[3] as Float,
+                            isPlayingValue = restored[4] as Boolean,
+                        )
+                    )
+                }
+            }
+        )
+
+
+    }
+
+
+
+}
+
+/**
+ * Data class representing various states of a player like control visibility, player mode,
+ * total duration, brightness level, and playback status.
+ */
+data class PlayerStates(
+    val areControlsVisible: Boolean = false,
+    val playerMode: PlayerModes = PlayerModes.MINI_PLAYER,
+    val totalDuration: Long = 0L,
+    val brightnessLevel: Float = 0f,
+    val isPlayingValue: Boolean = false,
+)
+
+/**
+ * Enum class defining player modes such as FULL_PLAYER and MINI_PLAYER.
+ */
+enum class PlayerModes {
+    FULL_PLAYER, MINI_PLAYER
+}


### PR DESCRIPTION
I've  enhanced the functionality to allow users to both access and update the ExoPlayer state. This improvement is aimed at increasing the flexibility and interactivity of our video player component within the Compose framework.

## New Features:
- **Direct State Access**: Users can now directly access the `ExoPlayerState` instance's current state. This allows for read operations on properties like brightness level, player mode, and playback status, enhancing the ability to display or use these states in other parts of the UI dynamically.
- **State Update Capability**: Alongside reading the state, users can also update the player's state using the `updateState` method. This method can be used to change properties like brightness or playback status, allowing for a more interactive and responsive user experience.

## Implementation Details:
- **Accessing State**: The `ExoPlayerState` class now exposes the current `PlayerStates` via its value property. Users can access the state like any other Compose state.
- **Updating State**: The `updateState` method has been refined to ensure updates are concise and reflect immediately on the UI. This method takes a `PlayerStates` object and applies it to the current state.

## Benefits:
- **Enhanced Control and Interactivity**: Users have more control over the player, leading to a richer, more interactive user experience.
- **Flexibility in UI Design**: Direct access to the player's state allows for more dynamic and responsive UI designs, where components can react in real time to changes in player state.
- **Encapsulation and Safety**: Despite the added flexibility, the encapsulation of player states and controlled update mechanism ensures that the player's integrity is maintained throughout its lifecycle.

I have ensured that these enhancements do not compromise the stability or performance of the player. Please review the changes for any potential improvements or adjustments needed.